### PR TITLE
🎨 Palette: Add "Clear All" button to search results

### DIFF
--- a/app/_components/cocktail-search-results.tsx
+++ b/app/_components/cocktail-search-results.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import type { Category, Cocktail, Ingredient } from "../types/cocktail";
 import { useCocktailSearch } from "../utils/useCocktailSearch";
 import { NoResults } from "./no-results";
+import { Button } from "./ui/button";
 
 interface CocktailSearchResultsProps {
 	cocktails: Cocktail[];
@@ -48,9 +49,20 @@ const CocktailSearchResults = React.memo(function CocktailSearchResults({
 					🔍 検索結果 ({cocktails.length}件)
 				</h2>
 
-				<p className="text-stone-600 dark:text-stone-400">
+				<p className="text-stone-600 dark:text-stone-400 mb-6">
 					選択された材料にマッチするレシピを表示しています
 				</p>
+
+				{onReset && (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={onReset}
+						aria-label="選択をすべてクリア"
+					>
+						選択をすべてクリア
+					</Button>
+				)}
 			</div>
 
 			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
Added a "Clear All" button to the search results header. This allows users to quickly reset their ingredient selection without having to scroll back to the top of the page, improving the overall search experience and accessibility. 

The button is conditionally rendered only when the `onReset` callback is provided, maintaining consistency with the `NoResults` component pattern.

♿ Accessibility:
- Added `aria-label="選択をすべてクリア"` to the button for screen reader users.
- Used the standard `Button` component which handles focus states and other accessibility requirements.

---
*PR created automatically by Jules for task [3603482467302356107](https://jules.google.com/task/3603482467302356107) started by @hndyu*