### PR TITLE
🎨 Palette: Add password visibility toggle to auth forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Icon-only Button Accessibility]
+**Learning:** Icon-only buttons, such as password visibility toggles, need explicit focus-visible styles (e.g., `focus-visible:text-primary`) to be clearly identifiable during keyboard navigation.
+**Action:** Always include focus-visible utility classes for icon-only buttons to enhance accessibility.

--- a/app/auth/sign-in/_components/sign-in-form.tsx
+++ b/app/auth/sign-in/_components/sign-in-form.tsx
@@ -3,7 +3,7 @@
 import authClient from "@/app/lib/authClient";
 import { isValidCallbackUrl } from "@/app/lib/url";
 import { Turnstile } from "@marsidev/react-turnstile";
-import { KeyRound } from "lucide-react";
+import { Eye, EyeOff, KeyRound } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -15,6 +15,7 @@ export default function SignInForm({
 }: { googleClientId?: string }) {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
+	const [showPassword, setShowPassword] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
 	const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
@@ -331,15 +332,29 @@ export default function SignInForm({
 						>
 							パスワード
 						</label>
-						<input
-							id="password"
-							type="password"
-							required
-							className="w-full bg-white dark:bg-stone-950 border border-stone-300 dark:border-stone-800 rounded-lg px-4 py-2 text-stone-900 dark:text-stone-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
-							value={password}
-							onChange={(e) => setPassword(e.target.value)}
-							data-testid="password-input"
-						/>
+						<div className="relative">
+							<input
+								id="password"
+								type={showPassword ? "text" : "password"}
+								required
+								className="w-full bg-white dark:bg-stone-950 border border-stone-300 dark:border-stone-800 rounded-lg pl-4 pr-10 py-2 text-stone-900 dark:text-stone-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								data-testid="password-input"
+							/>
+							<button
+								type="button"
+								onClick={() => setShowPassword(!showPassword)}
+								className="absolute inset-y-0 right-0 pr-3 flex items-center text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300 transition-colors focus-visible:outline-none focus-visible:text-primary"
+								aria-label={
+									showPassword
+										? "パスワードを非表示にする"
+										: "パスワードを表示する"
+								}
+							>
+								{showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+							</button>
+						</div>
 					</div>
 
 					{turnstileSiteKey && (

--- a/app/auth/sign-up/_components/sign-up-form.tsx
+++ b/app/auth/sign-up/_components/sign-up-form.tsx
@@ -3,6 +3,7 @@
 import authClient from "@/app/lib/authClient";
 import { isValidCallbackUrl } from "@/app/lib/url";
 import { Turnstile } from "@marsidev/react-turnstile";
+import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
@@ -14,6 +15,7 @@ export default function SignUpForm({
 }: { googleClientId?: string }) {
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
+	const [showPassword, setShowPassword] = useState(false);
 	const [name, setName] = useState("");
 	const [termsAgreed, setTermsAgreed] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -133,15 +135,29 @@ export default function SignUpForm({
 						>
 							パスワード
 						</label>
-						<input
-							id="password"
-							type="password"
-							required
-							className="w-full bg-white dark:bg-stone-950 border border-stone-300 dark:border-stone-800 rounded-lg px-4 py-2 text-stone-900 dark:text-stone-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
-							value={password}
-							onChange={(e) => setPassword(e.target.value)}
-							data-testid="password-input"
-						/>
+						<div className="relative">
+							<input
+								id="password"
+								type={showPassword ? "text" : "password"}
+								required
+								className="w-full bg-white dark:bg-stone-950 border border-stone-300 dark:border-stone-800 rounded-lg pl-4 pr-10 py-2 text-stone-900 dark:text-stone-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+								value={password}
+								onChange={(e) => setPassword(e.target.value)}
+								data-testid="password-input"
+							/>
+							<button
+								type="button"
+								onClick={() => setShowPassword(!showPassword)}
+								className="absolute inset-y-0 right-0 pr-3 flex items-center text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300 transition-colors focus-visible:outline-none focus-visible:text-primary"
+								aria-label={
+									showPassword
+										? "パスワードを非表示にする"
+										: "パスワードを表示する"
+								}
+							>
+								{showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+							</button>
+						</div>
 					</div>
 
 					{/* Terms Agreement */}

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,11 @@
+
+> yourmix@0.1.0 dev /app
+> next dev --turbopack
+
+ ⚠ Port 3000 is in use by an unknown process, using available port 3002 instead.
+   ▲ Next.js 15.5.15 (Turbopack)
+   - Local:        http://localhost:3002
+   - Network:      http://192.168.0.2:3002
+
+ ✓ Starting...
+ ✓ Ready in 5.7s

--- a/tests/unit/app/auth/sign-in/sign-in.test.tsx
+++ b/tests/unit/app/auth/sign-in/sign-in.test.tsx
@@ -33,6 +33,8 @@ vi.mock("@/app/lib/authClient", () => ({
 // Mock Lucide icons
 vi.mock("lucide-react", () => ({
 	KeyRound: () => <div data-testid="key-icon">Key Icon</div>,
+	Eye: () => <div data-testid="eye-icon">Eye Icon</div>,
+	EyeOff: () => <div data-testid="eye-off-icon">Eye Off Icon</div>,
 }));
 
 vi.mock("@marsidev/react-turnstile", () => ({
@@ -63,6 +65,22 @@ describe("SignInPage", () => {
 		expect(screen.getByTestId("password-input")).toBeInTheDocument();
 		expect(screen.getByTestId("sign-in-button")).toBeInTheDocument();
 		expect(screen.getByText("パスキーでログイン")).toBeInTheDocument();
+		expect(screen.getByLabelText("パスワードを表示する")).toBeInTheDocument();
+	});
+
+	it("toggles password visibility", () => {
+		render(<SignInPage />);
+		const passwordInput = screen.getByTestId("password-input");
+		const toggleButton = screen.getByLabelText("パスワードを表示する");
+
+		expect(passwordInput).toHaveAttribute("type", "password");
+
+		fireEvent.click(toggleButton);
+		expect(passwordInput).toHaveAttribute("type", "text");
+		expect(screen.getByLabelText("パスワードを非表示にする")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByLabelText("パスワードを非表示にする"));
+		expect(passwordInput).toHaveAttribute("type", "password");
 	});
 
 	it("handles successful sign in", async () => {


### PR DESCRIPTION
Added a password visibility toggle to the sign-in and sign-up forms to enhance UX and accessibility. Verified the changes with unit tests and Playwright screenshots.

---
*PR created automatically by Jules for task [12627296172464429405](https://jules.google.com/task/12627296172464429405) started by @hndyu*