### PR TITLE
🎨 Palette: Add Required Field Indicators to Auth Forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-04-25 - [Semantic Lists & External Link Hints]
 **Learning:** Semantic HTML is the foundation of accessibility. Using `<ol>` and `<li>` for breadcrumbs and instructions provides a clear structure for screen readers. Decorative markers (like "A", "B", or step numbers) should be hidden with `aria-hidden="true"` to avoid redundant announcements. For links opening in new windows (`target="_blank"`), a visually hidden hint like `（新しいウィンドウで開きます）` is essential for informing screen reader users of the change in context.
 **Action:** Use semantic lists for ordered content, hide decorative markers, and always provide visually hidden hints for external links.
+
+## 2026-05-01 - [Required Field Visual Indicators & Testing Patterns]
+**Learning:** Adding visual indicators (like a red asterisk) to required fields significantly improves form usability by reducing cognitive load. When implementing this within a `<label>`, it's critical to use `aria-hidden="true"` on the indicator to prevent screen reader noise, as the underlying `required` attribute already provides the semantic state. Additionally, this change requires updating Testing Library `getByLabelText` queries to use regular expressions to maintain robust test selection.
+**Action:** Always include visual "required" indicators in mandatory forms and use regex-based label matching in associated tests to accommodate the extra markup.

--- a/app/auth/sign-in/_components/sign-in-form.tsx
+++ b/app/auth/sign-in/_components/sign-in-form.tsx
@@ -186,6 +186,10 @@ export default function SignInForm({
 									className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-1"
 								>
 									バックアップコード
+									<span className="text-red-500" aria-hidden="true">
+										{" "}
+										*
+									</span>
 								</label>
 								<input
 									id="backup-code"
@@ -207,6 +211,10 @@ export default function SignInForm({
 										className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-1"
 									>
 										認証コード
+										<span className="text-red-500" aria-hidden="true">
+											{" "}
+											*
+										</span>
 									</label>
 									<input
 										id="2fa-code"
@@ -319,6 +327,10 @@ export default function SignInForm({
 							className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-1"
 						>
 							メールアドレス
+							<span className="text-red-500" aria-hidden="true">
+								{" "}
+								*
+							</span>
 						</label>
 						<input
 							id="email"
@@ -338,6 +350,10 @@ export default function SignInForm({
 							className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-1"
 						>
 							パスワード
+							<span className="text-red-500" aria-hidden="true">
+								{" "}
+								*
+							</span>
 						</label>
 						<div className="relative">
 							<input

--- a/app/auth/sign-up/_components/sign-up-form.tsx
+++ b/app/auth/sign-up/_components/sign-up-form.tsx
@@ -98,6 +98,10 @@ export default function SignUpForm({
 							className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-1"
 						>
 							名前
+							<span className="text-red-500" aria-hidden="true">
+								{" "}
+								*
+							</span>
 						</label>
 						<input
 							id="name"
@@ -116,6 +120,10 @@ export default function SignUpForm({
 							className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-1"
 						>
 							メールアドレス
+							<span className="text-red-500" aria-hidden="true">
+								{" "}
+								*
+							</span>
 						</label>
 						<input
 							id="email"
@@ -134,6 +142,10 @@ export default function SignUpForm({
 							className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-1"
 						>
 							パスワード
+							<span className="text-red-500" aria-hidden="true">
+								{" "}
+								*
+							</span>
 						</label>
 						<div className="relative">
 							<input

--- a/tests/unit/app/auth/sign-in/sign-in.test.tsx
+++ b/tests/unit/app/auth/sign-in/sign-in.test.tsx
@@ -250,11 +250,11 @@ describe("SignInPage", () => {
 		// Should show 2FA form
 		await waitFor(() => {
 			expect(screen.getByText("2要素認証")).toBeInTheDocument();
-			expect(screen.getByLabelText("認証コード")).toBeInTheDocument();
+			expect(screen.getByLabelText(/認証コード/)).toBeInTheDocument();
 		});
 
 		// Submit 2FA code
-		fireEvent.change(screen.getByLabelText("認証コード"), {
+		fireEvent.change(screen.getByLabelText(/認証コード/), {
 			target: { value: "123456" },
 		});
 		fireEvent.click(screen.getByText("認証してログイン"));
@@ -335,10 +335,10 @@ describe("SignInPage", () => {
 		// Switch to backup code mode
 		fireEvent.click(screen.getByText("バックアップコードを使用する"));
 
-		expect(screen.getByLabelText("バックアップコード")).toBeInTheDocument();
+		expect(screen.getByLabelText(/バックアップコード/)).toBeInTheDocument();
 
 		// Submit backup code
-		fireEvent.change(screen.getByLabelText("バックアップコード"), {
+		fireEvent.change(screen.getByLabelText(/バックアップコード/), {
 			target: { value: "ABCDEFGH" },
 		});
 		fireEvent.click(screen.getByText("認証してログイン"));


### PR DESCRIPTION
💡 What: Added visual "required" indicators (red asterisks `*`) to all mandatory fields in the authentication forms (Sign In, Sign Up, and 2FA).

🎯 Why: To clearly communicate which fields must be filled out before submission, improving form usability and reducing user errors.

📸 Before/After: Required fields previously looked identical to optional fields (though all fields in these forms happened to be required). Now they feature a consistent red asterisk next to the label.

♿ Accessibility: The indicators use `aria-hidden="true"` to prevent redundant announcements for screen reader users, who already receive the required state via the semantic `required` attribute on the input elements.

---
*PR created automatically by Jules for task [4125155475515959505](https://jules.google.com/task/4125155475515959505) started by @hndyu*