### PR TITLE
🎨 Palette: Add manual dismiss button to Toast component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-05-06 - [Dialog Keyboard Navigation & Body Scroll Locking]
 **Learning:** Manual dialog implementations often forget standard UX expectations: closing with the 'Escape' key and preventing the background content from scrolling. Managing these via centralized `useEffect` hooks linked to an aggregate 'open' state (e.g., `anyDialogOpen`) ensures consistent behavior across multiple modals within the same component and prevents common accessibility regressions.
 **Action:** For components with multiple dialogs/modals, implement a centralized Escape key listener and body scroll locking effect to ensure standard accessible behavior.
+
+## 2026-05-11 - [Manual Toast Dismissal & A11y]
+**Learning:** While auto-dismissing toasts are standard for non-critical information, providing a manual "close" button significantly improves UX for users who read faster or find persistent overlays distracting. For accessibility, icon-only dismiss buttons must have a clear `aria-label` (e.g., "閉じる"), tactile feedback (`active:scale-90`), and high-contrast focus rings (`focus-visible:ring-white`) to ensure they are discoverable and easy to interact with via keyboard or touch.
+**Action:** Always include a manual dismiss button in Toast/Notification components, ensuring it follows the repository's standard for accessible icon-only buttons.

--- a/app/_components/ui/toast.tsx
+++ b/app/_components/ui/toast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, CheckCircle, Info, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle, Info, X, XCircle } from "lucide-react";
 import * as React from "react";
 import { useEffect } from "react";
 
@@ -59,6 +59,14 @@ export function Toast({
 			>
 				{icons[severity]}
 				<span className="font-medium">{message}</span>
+				<button
+					type="button"
+					onClick={onClose}
+					className="ml-2 -mr-1 p-1 rounded-full hover:bg-white/20 transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+					aria-label="閉じる"
+				>
+					<X size={18} aria-hidden="true" />
+				</button>
 			</div>
 		</output>
 	);

--- a/tests/unit/app/_components/toast.test.tsx
+++ b/tests/unit/app/_components/toast.test.tsx
@@ -1,0 +1,86 @@
+import { Toast } from "@/app/_components/ui/toast";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock lucide-react icons
+vi.mock("lucide-react", () => ({
+	AlertTriangle: () => <div data-testid="icon-warning" />,
+	CheckCircle: () => <div data-testid="icon-success" />,
+	Info: () => <div data-testid="icon-info" />,
+	XCircle: () => <div data-testid="icon-error" />,
+	X: () => <div data-testid="icon-close" />,
+}));
+
+describe("Toast Component", () => {
+	it("renders the message when open is true", () => {
+		render(
+			<Toast
+				open={true}
+				message="Test Message"
+				severity="info"
+				onClose={() => {}}
+			/>,
+		);
+
+		expect(screen.getByText("Test Message")).toBeInTheDocument();
+		expect(screen.getByRole("status")).toBeInTheDocument();
+	});
+
+	it("does not render when open is false", () => {
+		render(
+			<Toast
+				open={false}
+				message="Test Message"
+				severity="info"
+				onClose={() => {}}
+			/>,
+		);
+
+		expect(screen.queryByText("Test Message")).not.toBeInTheDocument();
+	});
+
+	it("calls onClose when the close button is clicked", async () => {
+		const handleClose = vi.fn();
+		render(
+			<Toast
+				open={true}
+				message="Test Message"
+				severity="info"
+				onClose={handleClose}
+			/>,
+		);
+
+		const closeButton = screen.getByRole("button", { name: "閉じる" });
+		await userEvent.click(closeButton);
+
+		expect(handleClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders the correct icon based on severity", () => {
+		const { rerender } = render(
+			<Toast
+				open={true}
+				message="Success"
+				severity="success"
+				onClose={() => {}}
+			/>,
+		);
+		expect(screen.getByTestId("icon-success")).toBeInTheDocument();
+
+		rerender(
+			<Toast
+				open={true}
+				message="Warning"
+				severity="warning"
+				onClose={() => {}}
+			/>,
+		);
+		expect(screen.getByTestId("icon-warning")).toBeInTheDocument();
+
+		rerender(
+			<Toast open={true} message="Error" severity="error" onClose={() => {}} />,
+		);
+		expect(screen.getByTestId("icon-error")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
Implemented a manual dismiss button for the Toast component to improve usability and accessibility. Users can now close notifications immediately instead of waiting for the auto-hide timer. The change includes a new unit test and follows the project's established accessibility and tactile feedback patterns.

---
*PR created automatically by Jules for task [3144650229804825103](https://jules.google.com/task/3144650229804825103) started by @hndyu*