### PR TITLE
🎨 Palette: Standardize and improve keyboard focus indicators

### DIFF
--- a/app/_components/cocktail-display.tsx
+++ b/app/_components/cocktail-display.tsx
@@ -250,7 +250,7 @@ export default function CocktailDisplay({
 								<button
 									type="button"
 									onClick={handleShare}
-									className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all duration-200 active:scale-95 min-w-[100px] justify-center ${
+									className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-bold transition-all duration-200 active:scale-95 min-w-[100px] justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950 ${
 										isCopied
 											? "bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 border border-green-200 dark:border-green-800"
 											: "bg-secondary text-foreground hover:bg-secondary/80"

--- a/app/_components/footer.tsx
+++ b/app/_components/footer.tsx
@@ -10,13 +10,13 @@ export default function Footer() {
 				<div className="flex items-center gap-6">
 					<Link
 						href="/terms-of-service"
-						className="hover:text-stone-800 dark:hover:text-stone-300 transition-colors"
+						className="hover:text-stone-800 dark:hover:text-stone-300 transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
 					>
 						利用規約
 					</Link>
 					<Link
 						href="/privacy-policy"
-						className="hover:text-stone-800 dark:hover:text-stone-300 transition-colors"
+						className="hover:text-stone-800 dark:hover:text-stone-300 transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
 					>
 						プライバシーポリシー
 					</Link>

--- a/app/_components/header.tsx
+++ b/app/_components/header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
 				{/* Logo / Brand */}
 				<Link
 					href="/"
-					className="flex items-center gap-2 text-foreground hover:opacity-80 transition-all active:scale-95"
+					className="flex items-center gap-2 text-foreground hover:opacity-80 transition-all active:scale-95 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
 				>
 					<div
 						className="w-8 h-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground shadow-lg shadow-primary/40"

--- a/app/_components/ingredient-selector/ingredient-card.tsx
+++ b/app/_components/ingredient-selector/ingredient-card.tsx
@@ -118,7 +118,7 @@ const IngredientCard = React.memo(
 							type="button"
 							aria-expanded={expanded}
 							aria-label={`${ingredient.name}の銘柄・詳細を${expanded ? "閉じる" : "表示"}`}
-							className="expand-btn w-full px-4 py-2 flex items-center justify-between text-xs text-stone-600 dark:text-stone-500 hover:text-stone-800 dark:hover:text-stone-300 transition-all focus:outline-none focus:bg-stone-100 dark:focus:bg-stone-800/50 active:bg-stone-100 dark:active:bg-stone-800 active:scale-[0.98] rounded-b-2xl"
+							className="expand-btn w-full px-4 py-2 flex items-center justify-between text-xs text-stone-600 dark:text-stone-500 hover:text-stone-800 dark:hover:text-stone-300 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset active:bg-stone-100 dark:active:bg-stone-800 active:scale-[0.98] rounded-b-2xl"
 							onClick={(e) => {
 								e.stopPropagation();
 								setExpanded(!expanded);

--- a/app/_components/ui/button.tsx
+++ b/app/_components/ui/button.tsx
@@ -23,7 +23,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 		ref,
 	) => {
 		const baseStyles =
-			"inline-flex items-center justify-center rounded-xl font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-white dark:ring-offset-stone-950 active:scale-95";
+			"inline-flex items-center justify-center rounded-xl font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-white dark:ring-offset-stone-950 active:scale-95";
 
 		const variants = {
 			default:

--- a/app/recipes/[slug]/page.tsx
+++ b/app/recipes/[slug]/page.tsx
@@ -146,7 +146,10 @@ export default async function RecipeDetailPage({
 			>
 				<ol className="flex items-center">
 					<li className="flex items-center">
-						<Link href="/" className="hover:text-primary transition-colors">
+						<Link
+							href="/"
+							className="hover:text-primary transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
+						>
 							ホーム
 						</Link>
 						<ChevronRight size={16} className="mx-1" aria-hidden="true" />


### PR DESCRIPTION
💡 What: Added consistent and high-contrast focus indicators (`focus-visible:ring-primary`) to several interactive elements across the application, including the site logo, footer links, breadcrumbs, the share button, and the ingredient card detail toggles. Also updated the base `Button` component to use the primary theme color for its focus ring.

🎯 Why: Improves keyboard accessibility by ensuring that focused elements are clearly identifiable, making the application easier to navigate for users who rely on keyboards or other assistive technologies.

♿ Accessibility:
- Site logo, footer links, and breadcrumbs now have visible focus rings with appropriate offsets.
- The Share/Copy button in the cocktail display now correctly shows a focus ring.
- Ingredient card "銘柄・詳細" buttons now show an inset focus ring to prevent clipping.
- Standardized the use of `focus-visible:ring-primary` for all interactive elements to match the brand identity and provide better contrast than the previous stone-500 ring.

---
*PR created automatically by Jules for task [10240736669997567313](https://jules.google.com/task/10240736669997567313) started by @hndyu*