### PR TITLE
🎨 Palette: Standardize focus rings for ingredient selector

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -33,3 +33,7 @@
 ## 2026-05-11 - [Manual Toast Dismissal & A11y]
 **Learning:** While auto-dismissing toasts are standard for non-critical information, providing a manual "close" button significantly improves UX for users who read faster or find persistent overlays distracting. For accessibility, icon-only dismiss buttons must have a clear `aria-label` (e.g., "閉じる"), tactile feedback (`active:scale-90`), and high-contrast focus rings (`focus-visible:ring-white`) to ensure they are discoverable and easy to interact with via keyboard or touch.
 **Action:** Always include a manual dismiss button in Toast/Notification components, ensuring it follows the repository's standard for accessible icon-only buttons.
+
+## 2026-05-14 - Standardized High-Contrast Focus Rings
+**Learning:** Accessibility and visual consistency are improved by standardizing focus indicators across interactive components. Using `focus-visible` prevents rings from appearing on click for mouse users, while `ring-offset-2` (and `dark:ring-offset-stone-950`) ensures the focus indicator is always visible regardless of the component's background color or theme.
+**Action:** Always apply `focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950` to primary interactive elements, and consider `ring-offset-1` for smaller elements like tags or chips to maintain visual balance.

--- a/app/_components/ingredient-selector/ingredient-card.tsx
+++ b/app/_components/ingredient-selector/ingredient-card.tsx
@@ -51,7 +51,7 @@ const IngredientCard = React.memo(
 					type="button"
 					aria-pressed={isSelected}
 					aria-label={`${ingredient.name} を${isSelected ? "解除" : "選択"}`}
-					className={`flex flex-col p-4 flex-grow text-left w-full focus:outline-none focus:ring-2 focus:ring-primary/50 transition-transform active:scale-[0.98] ${
+					className={`flex flex-col p-4 flex-grow text-left w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950 transition-transform active:scale-[0.98] ${
 						hasDetails ? "rounded-t-2xl" : "rounded-2xl"
 					}`}
 					onClick={(e) => {
@@ -155,7 +155,7 @@ const IngredientCard = React.memo(
 												onDetailToggle(ingredient, name);
 											}}
 											className={`
-                      px-2 py-1 text-xs rounded-md border transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50
+                      px-2 py-1 text-xs rounded-md border transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 dark:focus-visible:ring-offset-stone-950
                       ${
 												isDetailSelected
 													? "bg-primary/20 border-primary text-foreground"

--- a/app/_components/ingredient-selector/ingredient-search.tsx
+++ b/app/_components/ingredient-selector/ingredient-search.tsx
@@ -58,7 +58,7 @@ export default function IngredientSearch({
 				ref={inputRef}
 				id="ingredient-search"
 				type="search"
-				className="block w-full pl-10 pr-10 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-stone-800 rounded-xl text-stone-900 dark:text-stone-200 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all shadow-inner"
+				className="block w-full pl-10 pr-10 py-3 bg-white dark:bg-stone-900 border border-stone-300 dark:border-stone-800 rounded-xl text-stone-900 dark:text-stone-200 placeholder-stone-400 dark:placeholder-stone-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950 transition-all shadow-inner"
 				placeholder="材料名で検索..."
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
@@ -80,7 +80,7 @@ export default function IngredientSearch({
 				<button
 					type="button"
 					onClick={handleClear}
-					className="absolute inset-y-0 right-0 pr-3 flex items-center text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300 transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-full"
+					className="absolute inset-y-0 right-0 pr-3 flex items-center text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300 transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950 rounded-full"
 					aria-label="検索をクリア"
 				>
 					<XCircle size={18} aria-hidden="true" />


### PR DESCRIPTION
Standardized focus indicators for `IngredientCard` and `IngredientSearch` components to follow the design system's high-contrast focus states.

- Added `focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2` to ingredient selection buttons and search inputs.
- Applied `focus-visible:ring-offset-1` to ingredient detail chips for visual balance.
- Standardized dark mode focus offsets with `dark:focus-visible:ring-offset-stone-950`.
- Ensured consistency with the project's accessibility standards across themes.

Verified through unit tests, manual focus inspection with Playwright screenshots, and a full production build.

---
*PR created automatically by Jules for task [18168669452925755325](https://jules.google.com/task/18168669452925755325) started by @hndyu*