### PR TITLE
🎨 Palette: Improve search empty state and focus management

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-05-16 - Completion Delight Pattern with Sparkles & Tooltips
 **Learning:** High-value actions (like viewing a custom AI-generated result) benefit from subtle celebratory cues. Adding a 'Sparkles' icon with a rotation animation on hover (`group-hover:rotate-12`) provides immediate positive feedback. Furthermore, including a native `title` attribute that matches the `aria-label` improves discoverability for desktop users while maintaining accessibility.
 **Action:** For primary action buttons in success/completion states, add celebratory icons with micro-animations and ensure `title` attributes are used alongside `aria-label` for consistency.
+
+## 2026-05-17 - Empty Search State Focus Management
+**Learning:** An empty search result state is a dead-end if not handled carefully. Providing a clear "Reset" or "Clear Search" button that programmatically returns focus to the search input via `useImperativeHandle` creates a seamless loop, allowing users to immediately try a different query without losing their place or needing extra clicks. Visual consistency with other reset actions (using `RotateCcw` and `gap-2`) further reinforces the app's interaction patterns.
+**Action:** Implement focus return logic in empty states to maintain user flow, and use standardized icons/classes for reset actions to ensure visual consistency.

--- a/app/_components/ingredient-selector/index.tsx
+++ b/app/_components/ingredient-selector/index.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import type { Category, Ingredient } from "@/app/types/cocktail";
+import { RotateCcw, SearchX } from "lucide-react";
 import * as React from "react";
 import { Button } from "../ui/button";
 import { Toast, type ToastSeverity } from "../ui/toast";
 import CategoryNav from "./category-nav";
 import IngredientCard from "./ingredient-card";
-import IngredientSearch from "./ingredient-search";
+import IngredientSearch, {
+	type IngredientSearchHandle,
+} from "./ingredient-search";
 import { useIngredientSelection } from "./use-ingredient-selection";
 
 interface IngredientSelectorProps {
@@ -33,6 +36,7 @@ export default function IngredientSelector({
 	const [activeCategory, setActiveCategory] = React.useState<string>(
 		categories[0]?.name || "その他",
 	);
+	const searchRef = React.useRef<IngredientSearchHandle>(null);
 
 	// Snackbar state
 	const [snackbar, setSnackbar] = React.useState<{
@@ -148,7 +152,11 @@ export default function IngredientSelector({
 			<div className="flex-1 min-w-0">
 				{/* Header Area */}
 				<div className="mb-6">
-					<IngredientSearch value={searchQuery} onChange={setSearchQuery} />
+					<IngredientSearch
+						ref={searchRef}
+						value={searchQuery}
+						onChange={setSearchQuery}
+					/>
 				</div>
 
 				{/* Grid */}
@@ -187,15 +195,24 @@ export default function IngredientSelector({
 						);
 					})}
 					{filteredIngredients.length === 0 && (
-						<div className="col-span-full text-center py-12 text-stone-500 flex flex-col items-center gap-4">
+						<div className="col-span-full text-center py-12 text-stone-500 flex flex-col items-center gap-4 animate-in fade-in slide-in-from-bottom-4 duration-500">
+							<SearchX
+								size={48}
+								className="text-stone-300 mb-2"
+								aria-hidden="true"
+							/>
 							<p>該当する材料が見つかりません</p>
 							{deferredSearchQuery && (
 								<Button
 									variant="outline"
 									size="sm"
-									onClick={() => setSearchQuery("")}
-									className="rounded-full"
+									onClick={() => {
+										setSearchQuery("");
+										searchRef.current?.focus();
+									}}
+									className="rounded-full gap-2"
 								>
+									<RotateCcw size={16} aria-hidden="true" />
 									検索をクリア
 								</Button>
 							)}

--- a/app/_components/ingredient-selector/ingredient-search.tsx
+++ b/app/_components/ingredient-selector/ingredient-search.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Search, XCircle } from "lucide-react";
+import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
 interface IngredientSearchProps {
@@ -8,12 +9,22 @@ interface IngredientSearchProps {
 	onChange: (value: string) => void;
 }
 
-export default function IngredientSearch({
-	value,
-	onChange,
-}: IngredientSearchProps) {
+export interface IngredientSearchHandle {
+	focus: () => void;
+}
+
+const IngredientSearch = React.forwardRef<
+	IngredientSearchHandle,
+	IngredientSearchProps
+>(({ value, onChange }, ref) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [isFocused, setIsFocused] = useState(false);
+
+	React.useImperativeHandle(ref, () => ({
+		focus: () => {
+			inputRef.current?.focus();
+		},
+	}));
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -82,6 +93,7 @@ export default function IngredientSearch({
 					onClick={handleClear}
 					className="absolute inset-y-0 right-0 pr-3 flex items-center text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300 transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950 rounded-full"
 					aria-label="検索をクリア"
+					title="検索をクリア"
 				>
 					<XCircle size={18} aria-hidden="true" />
 				</button>
@@ -100,4 +112,6 @@ export default function IngredientSearch({
 			)}
 		</div>
 	);
-}
+});
+
+export default IngredientSearch;


### PR DESCRIPTION
I have implemented a micro-UX improvement to the ingredient search functionality. 

### What
- **Empty State Polish:** Added a `SearchX` icon and a slide-in animation when no ingredients match the search query.
- **Focus Management:** Refactored `IngredientSearch` to expose a `focus()` method via `forwardRef`. The "Clear Search" button in the empty state now automatically returns focus to the search input after resetting the query.
- **Visual Consistency:** Standardized the reset button in the search empty state to use the `RotateCcw` icon and the `gap-2` class, matching other reset actions in the application.
- **Discoverability:** Added a `title` attribute to the icon-only clear button in the search input.

### Why
- Provides better feedback when a search returns no results.
- Improves the interaction flow for keyboard and power users by eliminating the need to manually re-focus the search field after clearing a failed query.
- Reinforces consistent UI patterns for destructive/reset actions across the app.

### Verification
- Ran Vitest unit tests for `IngredientSearch`, `IngredientCard`, and `NoResults`.
- Verified the UX flow with a Playwright script, capturing screenshots of the new empty state and confirming focus restoration.
- Ran Biome linting and TypeScript type checks.

---
*PR created automatically by Jules for task [12651775359595970968](https://jules.google.com/task/12651775359595970968) started by @hndyu*