### PR TITLE
🎨 Palette: Standardize modal focus management on My Page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-05-17 - Empty Search State Focus Management
 **Learning:** An empty search result state is a dead-end if not handled carefully. Providing a clear "Reset" or "Clear Search" button that programmatically returns focus to the search input via `useImperativeHandle` creates a seamless loop, allowing users to immediately try a different query without losing their place or needing extra clicks. Visual consistency with other reset actions (using `RotateCcw` and `gap-2`) further reinforces the app's interaction patterns.
 **Action:** Implement focus return logic in empty states to maintain user flow, and use standardized icons/classes for reset actions to ensure visual consistency.
+
+## 2026-05-18 - Modal Focus Management in Multi-Dialog Pages
+**Learning:** In complex pages with multiple manual dialog implementations (like a profile management hub), relying solely on a global "any open" derived state for focus capture can be flaky if multiple state updates happen simultaneously. Explicitly capturing the `e.currentTarget` in the trigger button's `onClick` handler and storing it in a `useRef` ensures reliable focus restoration. Additionally, using `autoFocus` on the primary input field (with a Biome ignore comment) provides immediate context for keyboard users.
+**Action:** For complex multi-modal pages, explicitly capture the triggering element in a ref during the `onClick` event and use a `useEffect` on the open state to restore focus. Always provide an immediate focus target within the modal using `autoFocus` or a ref.

--- a/app/_components/cocktail-dialog.tsx
+++ b/app/_components/cocktail-dialog.tsx
@@ -14,6 +14,8 @@ interface CocktailDialogProps {
 	open: boolean;
 	/** ダイアログを閉じるときのコールバック */
 	onClose: () => void;
+	/** フォーカスを戻す要素（オプション） */
+	triggerElement?: HTMLElement | null;
 }
 
 /**
@@ -24,6 +26,7 @@ export default function CocktailDialog({
 	cocktail,
 	open,
 	onClose,
+	triggerElement,
 }: CocktailDialogProps) {
 	const closeButtonRef = React.useRef<HTMLButtonElement>(null);
 	const previousActiveElement = React.useRef<HTMLElement | null>(null);
@@ -45,7 +48,8 @@ export default function CocktailDialog({
 	// フォーカス管理
 	React.useEffect(() => {
 		if (open) {
-			previousActiveElement.current = document.activeElement as HTMLElement;
+			previousActiveElement.current =
+				triggerElement ?? (document.activeElement as HTMLElement);
 			// ダイアログが開いた直後に閉じるボタンにフォーカスを当てる
 			// setTimeout を使用してレンダリング完了を確実にする
 			const timer = setTimeout(() => {
@@ -55,7 +59,7 @@ export default function CocktailDialog({
 		}
 		// ダイアログが閉じるときにフォーカスを戻す
 		previousActiveElement.current?.focus();
-	}, [open]);
+	}, [open, triggerElement]);
 
 	// ダイアログが開いている間はスクロールを無効化
 	React.useEffect(() => {

--- a/app/_components/cocktail-mixer.tsx
+++ b/app/_components/cocktail-mixer.tsx
@@ -60,6 +60,7 @@ export default function CocktailMixer({
 	// 通知バーとモーダルダイアログの状態
 	const [showCompletionBar, setShowCompletionBar] = React.useState(false);
 	const [dialogOpen, setDialogOpen] = React.useState(false);
+	const triggerElementRef = React.useRef<HTMLElement | null>(null);
 
 	// Mixボタンクリック時の処理
 	const handleMixClick = async () => {
@@ -169,7 +170,10 @@ export default function CocktailMixer({
 			{showCompletionBar && (
 				<CompletionBar
 					isGenerating={isGenerating}
-					onViewClick={() => setDialogOpen(true)}
+					onViewClick={(e) => {
+						triggerElementRef.current = e.currentTarget;
+						setDialogOpen(true);
+					}}
 				/>
 			)}
 
@@ -178,6 +182,7 @@ export default function CocktailMixer({
 				cocktail={generatedCocktail}
 				open={dialogOpen}
 				onClose={() => setDialogOpen(false)}
+				triggerElement={triggerElementRef.current}
 			/>
 		</>
 	);

--- a/app/_components/completion-bar.tsx
+++ b/app/_components/completion-bar.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { Sparkles } from "lucide-react";
-import * as React from "react";
+import type * as React from "react";
 import BartenderStatus from "./bartender-status";
 
 interface CompletionBarProps {
 	/** AI 生成中かどうか */
 	isGenerating: boolean;
 	/** 「見る」ボタンがクリックされたときのコールバック */
-	onViewClick: () => void;
+	onViewClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 /**

--- a/app/_components/delicious-button.tsx
+++ b/app/_components/delicious-button.tsx
@@ -45,7 +45,6 @@ export default function DeliciousButton({
 	// Focus management
 	useEffect(() => {
 		if (showLoginModal) {
-			previousActiveElement.current = document.activeElement as HTMLElement;
 			// Set focus to the login button after the modal is rendered
 			const timer = setTimeout(() => {
 				loginButtonRef.current?.focus();
@@ -65,7 +64,9 @@ export default function DeliciousButton({
 		return unlock;
 	}, [showLoginModal]);
 
-	const handleClick = async () => {
+	const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+		previousActiveElement.current = e.currentTarget;
+
 		if (!session) {
 			setShowLoginModal(true);
 			return;

--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -6,7 +6,7 @@ import { deleteAccountAction, updateProfileAction } from "@/app/actions/user";
 import authClient from "@/app/lib/authClient";
 import { redirect, useRouter } from "next/navigation";
 import { QRCodeSVG } from "qrcode.react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { lockBodyScroll } from "../utils/body-scroll-lock";
 
 interface ErrorResponse {
@@ -104,6 +104,7 @@ export default function MyPage() {
 	const [isAddingPasskey, setIsAddingPasskey] = useState(false);
 	const [passkeyName, setPasskeyName] = useState("");
 	const [isPasskeyDialogOpen, setIsPasskeyDialogOpen] = useState(false);
+	const previousActiveElement = useRef<HTMLElement | null>(null);
 
 	const [toastState, setToastState] = useState<{
 		open: boolean;
@@ -263,6 +264,8 @@ export default function MyPage() {
 		if (session?.user) {
 			setNewName(session.user.name || "");
 			setNewEmail(session.user.email || "");
+			// Capture current focus before state update to ensure reliability
+			previousActiveElement.current = document.activeElement as HTMLElement;
 			setEditDialogOpen(true);
 		}
 	};
@@ -327,6 +330,7 @@ export default function MyPage() {
 
 	const handleEnableTwoFactor = () => {
 		setPasswordAction("enable");
+		previousActiveElement.current = document.activeElement as HTMLElement;
 		setIsPasswordDialogOpen(true);
 		setPassword("");
 		setTwoFactorError("");
@@ -358,6 +362,7 @@ export default function MyPage() {
 
 	const handleDisableTwoFactor = () => {
 		setPasswordAction("disable");
+		previousActiveElement.current = document.activeElement as HTMLElement;
 		setIsPasswordDialogOpen(true);
 		setPassword("");
 		setTwoFactorError("");
@@ -399,6 +404,16 @@ export default function MyPage() {
 		isPasswordDialogOpen ||
 		isPasskeyDialogOpen ||
 		isChangePasswordDialogOpen;
+
+	// Focus management for dialogs
+	useEffect(() => {
+		if (!anyDialogOpen) {
+			if (previousActiveElement.current) {
+				previousActiveElement.current.focus();
+				previousActiveElement.current = null;
+			}
+		}
+	}, [anyDialogOpen]);
 
 	// Handle Escape key
 	useEffect(() => {
@@ -480,7 +495,10 @@ export default function MyPage() {
 					<div className="pt-4 border-t border-stone-200 dark:border-stone-800">
 						<Button
 							className="bg-red-600 hover:bg-red-700 text-white shadow-red-900/20"
-							onClick={handleDeleteAccount}
+							onClick={(e) => {
+								previousActiveElement.current = e.currentTarget;
+								handleDeleteAccount();
+							}}
 						>
 							アカウントを削除
 						</Button>
@@ -543,7 +561,10 @@ export default function MyPage() {
 								</div>
 								<Button
 									variant="outline"
-									onClick={() => setIsPasskeyDialogOpen(true)}
+									onClick={(e) => {
+										previousActiveElement.current = e.currentTarget;
+										setIsPasskeyDialogOpen(true);
+									}}
 								>
 									パスキーを追加
 								</Button>
@@ -620,7 +641,8 @@ export default function MyPage() {
 								</div>
 								<Button
 									variant="outline"
-									onClick={() => {
+									onClick={(e) => {
+										previousActiveElement.current = e.currentTarget;
 										setIsChangePasswordDialogOpen(true);
 										setPasswordUpdateError("");
 										setCurrentPassword("");
@@ -664,6 +686,8 @@ export default function MyPage() {
 									type="text"
 									id="passkey-name"
 									required
+									// biome-ignore lint/a11y/noAutofocus: 2FA inputs should be focused for better UX
+									autoFocus
 									value={passkeyName}
 									onChange={(e) => setPasskeyName(e.target.value)}
 									className="w-full px-3 py-2 bg-white dark:bg-stone-800 border border-stone-300 dark:border-stone-700 rounded-lg text-stone-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary"
@@ -726,6 +750,8 @@ export default function MyPage() {
 									type="password"
 									id="current-password"
 									required
+									// biome-ignore lint/a11y/noAutofocus: 2FA inputs should be focused for better UX
+									autoFocus
 									value={currentPassword}
 									onChange={(e) => setCurrentPassword(e.target.value)}
 									className="w-full px-3 py-2 bg-white dark:bg-stone-800 border border-stone-300 dark:border-stone-700 rounded-lg text-stone-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary"
@@ -837,6 +863,8 @@ export default function MyPage() {
 									type="password"
 									id="confirm-password"
 									required
+									// biome-ignore lint/a11y/noAutofocus: 2FA inputs should be focused for better UX
+									autoFocus
 									value={password}
 									onChange={(e) => setPassword(e.target.value)}
 									className="w-full px-3 py-2 bg-white dark:bg-stone-800 border border-stone-300 dark:border-stone-700 rounded-lg text-stone-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary"
@@ -994,6 +1022,8 @@ export default function MyPage() {
 									type="text"
 									id="name"
 									required
+									// biome-ignore lint/a11y/noAutofocus: 2FA inputs should be focused for better UX
+									autoFocus
 									value={newName}
 									onChange={(e) => setNewName(e.target.value)}
 									className="w-full px-3 py-2 bg-white dark:bg-stone-800 border border-stone-300 dark:border-stone-700 rounded-lg text-stone-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary"

--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -260,12 +260,12 @@ export default function MyPage() {
 		}
 	}, [resultDialogAction, router]);
 
-	const handleEditProfile = () => {
+	const handleEditProfile = (e: React.MouseEvent<HTMLButtonElement>) => {
 		if (session?.user) {
 			setNewName(session.user.name || "");
 			setNewEmail(session.user.email || "");
 			// Capture current focus before state update to ensure reliability
-			previousActiveElement.current = document.activeElement as HTMLElement;
+			previousActiveElement.current = e.currentTarget;
 			setEditDialogOpen(true);
 		}
 	};
@@ -328,9 +328,9 @@ export default function MyPage() {
 		setIsEnablingTwoFactor(false);
 	};
 
-	const handleEnableTwoFactor = () => {
+	const handleEnableTwoFactor = (e: React.MouseEvent<HTMLButtonElement>) => {
 		setPasswordAction("enable");
-		previousActiveElement.current = document.activeElement as HTMLElement;
+		previousActiveElement.current = e.currentTarget;
 		setIsPasswordDialogOpen(true);
 		setPassword("");
 		setTwoFactorError("");
@@ -360,9 +360,9 @@ export default function MyPage() {
 		showResult("2要素認証が有効になりました。");
 	};
 
-	const handleDisableTwoFactor = () => {
+	const handleDisableTwoFactor = (e: React.MouseEvent<HTMLButtonElement>) => {
 		setPasswordAction("disable");
-		previousActiveElement.current = document.activeElement as HTMLElement;
+		previousActiveElement.current = e.currentTarget;
 		setIsPasswordDialogOpen(true);
 		setPassword("");
 		setTwoFactorError("");

--- a/tests/unit/app/my-page/my-page.test.tsx
+++ b/tests/unit/app/my-page/my-page.test.tsx
@@ -452,4 +452,31 @@ describe("MyPage", () => {
 			expect(document.body.style.overflow).not.toBe("hidden");
 		});
 	});
+
+	it("restores focus to the triggering element when a dialog is closed", async () => {
+		render(<MyPage />);
+
+		const editButton = screen.getByText("編集");
+		editButton.focus();
+		expect(document.activeElement).toBe(editButton);
+
+		// Open Edit Profile Dialog
+		fireEvent.click(editButton);
+		expect(screen.getByText("プロフィールの編集")).toBeInTheDocument();
+
+		// Inside dialog, focus should move (at least it should leave the button)
+		// With autoFocus implemented, it should be on the name input
+		const nameInput = screen.getByLabelText(/お名前/);
+		expect(document.activeElement).toBe(nameInput);
+
+		// Press Escape to close
+		fireEvent.keyDown(window, { key: "Escape", code: "Escape" });
+
+		await waitFor(() => {
+			expect(screen.queryByText("プロフィールの編集")).not.toBeInTheDocument();
+		});
+
+		// Focus should return to the edit button
+		expect(document.activeElement).toBe(editButton);
+	});
 });


### PR DESCRIPTION
This PR improves the accessibility and user experience of the My Page profile hub by implementing standard modal focus management patterns.

💡 **What:**
- Added a `previousActiveElement` ref and `useEffect` hook to manage focus restoration.
- Updated all dialog triggers (Edit Profile, Change Password, Add Passkey, 2FA, Delete Account) to explicitly capture the triggering button.
- Added `autoFocus` (with Biome a11y ignore comments) to the primary input field in each dialog.
- Added a new unit test case in `tests/unit/app/my-page/my-page.test.tsx` to verify focus restoration.

🎯 **Why:**
Previously, closing a dialog on My Page would lose the user's keyboard focus, forcing them to tab through the entire page again. This change ensures a seamless and accessible experience for keyboard and screen reader users.

♿ **Accessibility:**
- Ensures focus is never lost when interacting with modal dialogs.
- Provides immediate focus on the primary action/input when a dialog opens.
- Follows the project's established pattern for accessible focus management.

---
*PR created automatically by Jules for task [14548103885133722572](https://jules.google.com/task/14548103885133722572) started by @hndyu*