### PR TITLE
🎨 Palette: Standardize user menu focus and tactile feedback

### DIFF
--- a/app/_components/auth-controls.tsx
+++ b/app/_components/auth-controls.tsx
@@ -109,7 +109,7 @@ export default function AuthControls() {
 						<div className="p-1">
 							<Link
 								href="/my-page"
-								className="flex items-center gap-2 px-3 py-2 text-sm text-stone-300 hover:bg-stone-800 hover:text-white focus:bg-stone-800 focus:text-white focus:outline-none rounded-lg transition-colors"
+								className="flex items-center gap-2 px-3 py-2 text-sm text-stone-300 hover:bg-stone-800 hover:text-white focus:outline-none focus:bg-stone-800 focus:text-white focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset rounded-lg transition-all active:scale-[0.98]"
 								onClick={() => setIsOpen(false)}
 							>
 								<User size={18} className="text-stone-500" aria-hidden="true" />
@@ -118,7 +118,7 @@ export default function AuthControls() {
 							<button
 								type="button"
 								onClick={handleSignOut}
-								className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-red-500/10 hover:text-red-300 focus:bg-red-500/10 focus:text-red-300 focus:outline-none rounded-lg transition-colors text-left"
+								className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-red-500/10 hover:text-red-300 focus:outline-none focus:bg-red-500/10 focus:text-red-300 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset rounded-lg transition-all active:scale-[0.98] text-left"
 							>
 								<LogOut size={18} aria-hidden="true" />
 								ログアウト

--- a/app/tags/[tagName]/page.tsx
+++ b/app/tags/[tagName]/page.tsx
@@ -61,7 +61,10 @@ export default async function TagPage({ params }: TagPageProps) {
 			>
 				<ol className="flex items-center">
 					<li className="flex items-center">
-						<Link href="/" className="hover:text-primary transition-colors">
+						<Link
+							href="/"
+							className="hover:text-primary transition-all active:scale-95 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
+						>
 							ホーム
 						</Link>
 						<ChevronRight size={16} className="mx-1" aria-hidden="true" />


### PR DESCRIPTION
🎨 **What:** This PR implements two micro-UX improvements focused on accessibility and tactile feedback.
1. **User Menu Standardization:** In `app/_components/auth-controls.tsx`, the menu items (My Page and Logout) now use high-contrast `focus-visible:ring-inset` indicators and `active:scale-[0.98]` tactile feedback while maintaining their background focus highlight for visibility.
2. **Breadcrumb Accessibility:** In `app/tags/[tagName]/page.tsx`, the breadcrumb "Home" link now includes standard high-contrast focus rings and `active:scale-95` feedback, matching the behavior of breadcrumbs on recipe pages.

🎯 **Why:** These changes ensure that interactive elements have clear, accessible focus states for keyboard users and provide immediate, delightful feedback for mouse and touch users, adhering to the project's standardized UX patterns.

♿ **Accessibility:** Added `focus-visible` rings with offset and inset where appropriate to ensure the indicator is visible regardless of background color or container boundaries. Verified that focus indicators are high-contrast and non-redundant.

---
*PR created automatically by Jules for task [6009881151536582881](https://jules.google.com/task/6009881151536582881) started by @hndyu*