### PR TITLE
🎨 Palette: Standardize reset actions and enhance empty states

### DIFF
--- a/app/_components/cocktail-dialog.tsx
+++ b/app/_components/cocktail-dialog.tsx
@@ -101,6 +101,7 @@ export default function CocktailDialog({
 					onClick={onClose}
 					className="sticky top-4 float-right mr-4 z-20 p-2 rounded-full bg-background/80 backdrop-blur-sm border border-border text-muted-foreground hover:text-foreground hover:bg-background transition-all active:scale-90 shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950"
 					aria-label="閉じる"
+					title="閉じる"
 				>
 					<X size={20} aria-hidden="true" />
 				</button>

--- a/app/_components/ingredient-selector/index.tsx
+++ b/app/_components/ingredient-selector/index.tsx
@@ -198,10 +198,12 @@ export default function IngredientSelector({
 						<div className="col-span-full text-center py-12 text-stone-500 flex flex-col items-center gap-4 animate-in fade-in slide-in-from-bottom-4 duration-500">
 							<SearchX
 								size={48}
-								className="text-stone-300 mb-2"
+								className="text-stone-300 dark:text-stone-500 mb-2"
 								aria-hidden="true"
 							/>
-							<p>該当する材料が見つかりません</p>
+							<h3 className="text-xl font-bold text-foreground">
+								該当する材料が見つかりません
+							</h3>
 							{deferredSearchQuery && (
 								<Button
 									variant="outline"
@@ -210,9 +212,14 @@ export default function IngredientSelector({
 										setSearchQuery("");
 										searchRef.current?.focus();
 									}}
-									className="rounded-full gap-2"
+									title="検索をクリア"
+									className="rounded-full gap-2 group"
 								>
-									<RotateCcw size={16} aria-hidden="true" />
+									<RotateCcw
+										size={16}
+										aria-hidden="true"
+										className="group-hover:-rotate-45 transition-transform"
+									/>
 									検索をクリア
 								</Button>
 							)}

--- a/app/_components/no-results.tsx
+++ b/app/_components/no-results.tsx
@@ -14,7 +14,7 @@ export function NoResults({ show, onReset }: NoResultsProps) {
 	return (
 		<div className="w-full max-w-2xl mx-auto mt-8 p-8 text-center bg-card border border-border rounded-2xl animate-in fade-in slide-in-from-bottom-4 duration-700">
 			<SearchX
-				className="text-stone-300 dark:text-stone-600 mb-4 mx-auto"
+				className="text-stone-300 dark:text-stone-500 mb-4 mx-auto"
 				size={48}
 				aria-hidden="true"
 			/>
@@ -31,10 +31,14 @@ export function NoResults({ show, onReset }: NoResultsProps) {
 					variant="outline"
 					size="sm"
 					onClick={onReset}
-					aria-label="選択をすべてクリア"
-					className="gap-2"
+					title="選択をすべてクリア"
+					className="gap-2 group"
 				>
-					<RotateCcw size={16} aria-hidden="true" />
+					<RotateCcw
+						size={16}
+						aria-hidden="true"
+						className="group-hover:-rotate-45 transition-transform"
+					/>
 					選択をすべてクリア
 				</Button>
 			)}

--- a/app/_components/ui/toast.tsx
+++ b/app/_components/ui/toast.tsx
@@ -64,6 +64,7 @@ export function Toast({
 					onClick={onClose}
 					className="ml-2 -mr-1 p-1 rounded-full hover:bg-white/20 transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
 					aria-label="閉じる"
+					title="閉じる"
 				>
 					<X size={18} aria-hidden="true" />
 				</button>


### PR DESCRIPTION
This PR adds a series of small, delightful UX and accessibility improvements across several core components.

💡 What:
1. Standardized the visual affordance for "Reset" actions by adding a subtle rotation animation to the RotateCcw icon on hover.
2. Improved the visual hierarchy of empty search states by upgrading labels to headings.
3. Added native title tooltips to icon-only buttons for better desktop discoverability.
4. Cleaned up redundant ARIA labels where visible text was already sufficient.

🎯 Why:
To create a more consistent and polished feel across the application while ensuring standard accessibility patterns are followed (e.g., providing tooltips for icon-only controls and maintaining proper heading structures).

♿ Accessibility:
- Added title attributes to icon-only buttons.
- Ensured proper semantic heading hierarchy in empty states.
- Removed redundant ARIA labels.
- Optimized decorative icon contrast for dark mode.

---
*PR created automatically by Jules for task [12656669197757033258](https://jules.google.com/task/12656669197757033258) started by @hndyu*