### PR TITLE
🎨 Palette: Add Copy Description Button to Cocktail Display

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,7 @@
 ## 2026-05-24 - Standardized Form Input Focus Experience
 **Learning:** Accessibility and visual consistency are paramount in form design. Unlike buttons, text-based inputs should provide immediate focus feedback regardless of the interaction method (mouse or keyboard). Standardizing on `focus:ring-2` with `focus:ring-offset-2` and `transition-all` ensures a high-contrast, responsive indicator that works across all themes and input devices. Additionally, enhancing icon-only toggles within inputs (like password visibility) with tactile feedback (`active:scale-90`) and native tooltips (`title`) improves both usability and discoverability.
 **Action:** Apply a consistent focus ring pattern to all form inputs (`focus:ring-2 focus:ring-primary focus:ring-offset-2 dark:focus:ring-offset-stone-950 transition-all`) and ensure nested interactive elements provide clear tactile and descriptive feedback.
+
+## 2025-05-27 - Hover-reveal Copy Buttons for Content Density
+**Learning:** For secondary actions like copying a specific text block, using a hover-reveal pattern (group-hover) helps maintain a clean UI for casual readers while providing power-user tools on demand. Immediate visual feedback (icon change + toast) is crucial to confirm the invisible action.
+**Action:** Apply `group` to containers and `opacity-0 group-hover:opacity-100` to secondary actions like copy buttons.

--- a/app/_components/cocktail-display.tsx
+++ b/app/_components/cocktail-display.tsx
@@ -59,6 +59,7 @@ export default function CocktailDisplay({
 		: [];
 	const [isWebShareSupported, setIsWebShareSupported] = React.useState(false);
 	const [isCopied, setIsCopied] = React.useState(false);
+	const [isDescriptionCopied, setIsDescriptionCopied] = React.useState(false);
 	const [completedSteps, setCompletedSteps] = React.useState<Set<number>>(
 		new Set(),
 	);
@@ -78,12 +79,16 @@ export default function CocktailDisplay({
 	}, []);
 
 	const copyTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+	const copyDescriptionTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
 
 	// Cleanup timeout on unmount
 	React.useEffect(() => {
 		return () => {
 			if (copyTimeoutRef.current) {
 				clearTimeout(copyTimeoutRef.current);
+			}
+			if (copyDescriptionTimeoutRef.current) {
+				clearTimeout(copyDescriptionTimeoutRef.current);
 			}
 		};
 	}, []);
@@ -113,6 +118,33 @@ export default function CocktailDisplay({
 				open: true,
 				message: "コピーしました!",
 				severity: "success",
+			});
+		}
+	};
+
+	const handleCopyDescription = async () => {
+		if (!cocktail.description) return;
+		try {
+			await navigator.clipboard.writeText(cocktail.description);
+			setIsDescriptionCopied(true);
+			if (copyDescriptionTimeoutRef.current) {
+				clearTimeout(copyDescriptionTimeoutRef.current);
+			}
+			copyDescriptionTimeoutRef.current = setTimeout(
+				() => setIsDescriptionCopied(false),
+				2000,
+			);
+			setToastState({
+				open: true,
+				message: "説明文をコピーしました!",
+				severity: "success",
+			});
+		} catch (err) {
+			console.error("Failed to copy description: ", err);
+			setToastState({
+				open: true,
+				message: "コピーに失敗しました",
+				severity: "error",
 			});
 		}
 	};
@@ -206,12 +238,33 @@ export default function CocktailDisplay({
 									{cocktail.name}
 								</h2>
 							)}
-							<p
-								id={descriptionId}
-								className="text-muted-foreground text-lg leading-relaxed italic"
-							>
-								{cocktail.description}
-							</p>
+							{cocktail.description && (
+								<div className="flex items-start gap-2 group/desc">
+									<p
+										id={descriptionId}
+										className="text-muted-foreground text-lg leading-relaxed italic flex-1"
+									>
+										{cocktail.description}
+									</p>
+									<button
+										type="button"
+										onClick={handleCopyDescription}
+										className={`shrink-0 p-1.5 rounded-lg transition-all active:scale-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950 ${
+											isDescriptionCopied
+												? "text-green-500 bg-green-500/10"
+												: "text-muted-foreground hover:text-foreground hover:bg-secondary opacity-0 group-hover/desc:opacity-100 focus-visible:opacity-100"
+										}`}
+										aria-label="説明文をコピー"
+										title="説明文をコピー"
+									>
+										{isDescriptionCopied ? (
+											<Check size={16} aria-hidden="true" />
+										) : (
+											<Copy size={16} aria-hidden="true" />
+										)}
+									</button>
+								</div>
+							)}
 
 							{/* Tags */}
 							<div className="flex flex-wrap gap-2">


### PR DESCRIPTION
Implemented a micro-UX improvement in `CocktailDisplay` that allows users to easily copy the cocktail description to their clipboard. The button appears on hover to maintain a clean interface and provides immediate visual feedback via a toast message and an icon change (Check icon). This enhancement improves the utility of the recipe display while adhering to the project's accessibility and interaction standards.

---
*PR created automatically by Jules for task [10989563883056823739](https://jules.google.com/task/10989563883056823739) started by @hndyu*