### PR TITLE
🎨 Palette: Add instruction reset and improve tactile feedback

### DIFF
--- a/app/_components/cocktail-display.tsx
+++ b/app/_components/cocktail-display.tsx
@@ -4,6 +4,7 @@ import {
 	Check,
 	Copy,
 	HelpCircle,
+	RotateCcw,
 	Share2,
 	ShoppingCart,
 	Tag,
@@ -281,7 +282,7 @@ export default function CocktailDisplay({
 									>
 										<Link
 											href={`/tags/${encodeURIComponent(tag.name)}`}
-											className="flex items-center gap-1.5 px-3 py-1 hover:bg-secondary/80 hover:text-foreground transition-colors rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950"
+											className="inline-flex items-center gap-1.5 px-3 py-1 hover:bg-secondary/80 hover:text-foreground transition-all active:scale-95 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950"
 										>
 											<Tag size={16} className="shrink-0" aria-hidden="true" />
 											{tag.name}
@@ -429,15 +430,33 @@ export default function CocktailDisplay({
 
 						{/* Instructions */}
 						<div>
-							<h3 className="text-2xl font-bold text-foreground mb-6 flex items-center gap-3">
-								<span
-									className="w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center text-primary text-sm"
-									aria-hidden="true"
-								>
-									B
-								</span>
-								作り方
-							</h3>
+							<div className="flex items-center justify-between mb-6">
+								<h3 className="text-2xl font-bold text-foreground flex items-center gap-3">
+									<span
+										className="w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center text-primary text-sm"
+										aria-hidden="true"
+									>
+										B
+									</span>
+									作り方
+								</h3>
+								{completedSteps.size > 0 && (
+									<button
+										type="button"
+										onClick={() => setCompletedSteps(new Set())}
+										className="group flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold text-muted-foreground hover:text-foreground bg-secondary/50 hover:bg-secondary rounded-full transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 dark:focus-visible:ring-offset-stone-950 animate-in fade-in zoom-in-95 duration-200"
+										aria-label="進捗をリセット"
+										title="進捗をリセット"
+									>
+										<RotateCcw
+											size={14}
+											aria-hidden="true"
+											className="transition-transform group-hover:-rotate-45"
+										/>
+										リセット
+									</button>
+								)}
+							</div>
 
 							{/* コネクターラインは ol の外でラップ div を基準に絶対配置する */}
 							<div className="relative">
@@ -458,7 +477,7 @@ export default function CocktailDisplay({
 													type="button"
 													onClick={() => toggleStep(index)}
 													aria-pressed={isStepCompleted}
-													className="flex gap-4 w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-8 rounded-lg transition-all"
+													className="flex gap-4 w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-8 rounded-lg transition-all active:scale-[0.98]"
 												>
 													<span className="sr-only">
 														ステップ {index + 1}

--- a/app/recipes/[slug]/page.tsx
+++ b/app/recipes/[slug]/page.tsx
@@ -148,7 +148,7 @@ export default async function RecipeDetailPage({
 					<li className="flex items-center">
 						<Link
 							href="/"
-							className="hover:text-primary transition-colors rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
+							className="inline-block hover:text-primary transition-all active:scale-95 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
 						>
 							ホーム
 						</Link>

--- a/app/tags/[tagName]/page.tsx
+++ b/app/tags/[tagName]/page.tsx
@@ -63,7 +63,7 @@ export default async function TagPage({ params }: TagPageProps) {
 					<li className="flex items-center">
 						<Link
 							href="/"
-							className="hover:text-primary transition-all active:scale-95 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
+							className="inline-block hover:text-primary transition-all active:scale-95 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-4 dark:focus-visible:ring-offset-stone-950"
 						>
 							ホーム
 						</Link>

--- a/tests/unit/app/_components/cocktail-display.test.tsx
+++ b/tests/unit/app/_components/cocktail-display.test.tsx
@@ -233,4 +233,35 @@ describe("CocktailDisplay Component", () => {
 		expect(firstStepButton).toHaveAttribute("aria-pressed", "false");
 		expect(screen.getByText(/ステップ 1（未完了）/)).toBeInTheDocument();
 	});
+
+	it("resets all steps when reset button is clicked", async () => {
+		render(<CocktailDisplay cocktail={mockCocktail} />);
+
+		const firstStepButton = screen.getByRole("button", {
+			name: /ステップ 1/,
+		});
+		const secondStepButton = screen.getByRole("button", {
+			name: /ステップ 2/,
+		});
+
+		// Complete two steps
+		await userEvent.click(firstStepButton);
+		await userEvent.click(secondStepButton);
+
+		expect(firstStepButton).toHaveAttribute("aria-pressed", "true");
+		expect(secondStepButton).toHaveAttribute("aria-pressed", "true");
+
+		// Find and click reset button
+		const resetButton = screen.getByRole("button", { name: "進捗をリセット" });
+		await userEvent.click(resetButton);
+
+		// Verify both steps are uncompleted
+		expect(firstStepButton).toHaveAttribute("aria-pressed", "false");
+		expect(secondStepButton).toHaveAttribute("aria-pressed", "false");
+
+		// Reset button should disappear
+		expect(
+			screen.queryByRole("button", { name: "進捗をリセット" }),
+		).not.toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
### 🎨 Palette: Instruction Reset & Tactile Polish

#### 💡 What:
- **Instruction Reset:** Added a "リセット" (Reset) button to the instructions section in `CocktailDisplay`. This button appears only when at least one step is completed, allowing users to clear their progress with a single click.
- **Tactile Feedback:** Applied `active:scale-95` (for links/breadcrumbs) and `active:scale-[0.98]` (for larger buttons) transitions across the app to provide immediate physical confirmation of user interactions.
- **Visual Consistency:** Ensured breadcrumb and tag links are `inline-block` or `inline-flex` so that scale transforms apply correctly without layout shifts.

#### 🎯 Why:
- Improves the "cooking" UX by allowing users to easily restart a recipe if they make a mistake or want to make another round.
- Enhances the overall feel of the application by making interactive elements feel more responsive and "alive" through subtle micro-animations.

#### ♿ Accessibility:
- The new Reset button follows the project's standard for accessible icon buttons with clear `aria-label`, `title`, and high-contrast focus rings.
- Preserved the accessible pattern for instruction steps (using `sr-only` for status) while adding a more prominent "active" state.
- Verified focus management and keyboard navigation on all modified elements.

#### ✅ Verification:
- **Unit Tests:** Added a new test case in `cocktail-display.test.tsx` to verify the reset functionality. All 229 tests passed.
- **Visual:** Verified using a Playwright script and manual inspection of screenshots.
- **Linting:** Biome check passed with no issues.

---
*PR created automatically by Jules for task [343733249595751406](https://jules.google.com/task/343733249595751406) started by @hndyu*