### PR TITLE
🎨 Palette: Branded and Accessible Error Page Enhancement

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Button } from "@/app/_components/ui/button";
+import { AlertTriangle, Martini, RotateCcw } from "lucide-react";
 import * as React from "react";
 import { useEffect } from "react";
 
@@ -20,14 +21,55 @@ export default function CustomError({
 	}, [error]);
 
 	return (
-		<div className="flex flex-col items-center justify-center min-h-[80vh] text-center p-6">
-			<h1 className="text-2xl md:text-3xl font-bold mb-4">
-				予期せぬエラーが発生しました
-			</h1>
-			<p className="text-stone-600 dark:text-stone-400 mb-8">
-				ご迷惑をおかけしております。時間をおいて再度お試しください。
-			</p>
-			<Button onClick={() => reset()}>再試行</Button>
+		<div className="flex flex-col items-center justify-center min-h-[70vh] text-center p-6 gap-8 animate-in fade-in duration-700">
+			<div className="relative group">
+				<div
+					className="absolute -top-2 -right-2 text-red-500 animate-pulse"
+					aria-hidden="true"
+				>
+					<AlertTriangle size={24} />
+				</div>
+				<div className="w-24 h-24 rounded-full bg-primary/10 flex items-center justify-center text-primary transition-transform group-hover:rotate-12 duration-500">
+					<Martini size={48} aria-hidden="true" />
+				</div>
+			</div>
+
+			<div className="space-y-4">
+				<h1 className="font-bold text-foreground">
+					<span
+						className="font-display text-7xl md:text-8xl text-primary/10 block mb-2 select-none uppercase tracking-widest"
+						aria-hidden="true"
+					>
+						Error
+					</span>
+					<span className="text-2xl md:text-3xl">
+						予期せぬエラーが発生しました
+					</span>
+				</h1>
+				<p className="text-stone-500 dark:text-stone-400 max-w-md mx-auto leading-relaxed">
+					ご迷惑をおかけしております。
+					<br />
+					一時的な問題の可能性があります。時間をおいて再度お試しください。
+				</p>
+				{error.digest && (
+					<p className="text-[10px] font-mono text-stone-400 dark:text-stone-600 mt-4 opacity-50">
+						ID: {error.digest}
+					</p>
+				)}
+			</div>
+
+			<Button
+				onClick={() => reset()}
+				size="lg"
+				className="min-w-[200px] gap-2 group"
+			>
+				<RotateCcw
+					size={18}
+					aria-hidden="true"
+					className="group-hover:-rotate-45 transition-transform"
+				/>
+				再試行
+			</Button>
 		</div>
 	);
 }

--- a/tests/unit/app/error.test.tsx
+++ b/tests/unit/app/error.test.tsx
@@ -18,16 +18,21 @@ describe("CustomError", () => {
 		mockReset.mockClear();
 	});
 
+	// Mock Lucide icons
+	vi.mock("lucide-react", () => ({
+		AlertTriangle: () => <div data-testid="alert-triangle-icon" />,
+		Martini: () => <div data-testid="martini-icon" />,
+		RotateCcw: () => <div data-testid="rotate-ccw-icon" />,
+	}));
+
 	it("エラーメッセージと再試行ボタンが正しくレンダリングされる", () => {
 		render(<CustomError error={mockError} reset={mockReset} />);
 
 		expect(
-			screen.getByRole("heading", { name: "予期せぬエラーが発生しました" }),
+			screen.getByRole("heading", { name: /予期せぬエラーが発生しました/ }),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(
-				"ご迷惑をおかけしております。時間をおいて再度お試しください。",
-			),
+			screen.getByText(/ご迷惑をおかけしております。/),
 		).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "再試行" })).toBeInTheDocument();
 	});


### PR DESCRIPTION
I have enhanced the Error page (`app/error.tsx`) to provide a more branded and pleasant failure experience, matching the style of the 404 page. Key improvements include the addition of brand-aligned icons (`Martini`, `AlertTriangle`), decorative typography, and micro-animations on the retry action. I also ensured the error digest is visible for easier troubleshooting. The associated unit tests have been updated and verified to pass.

---
*PR created automatically by Jules for task [18383735906250943706](https://jules.google.com/task/18383735906250943706) started by @hndyu*